### PR TITLE
2020-12-07: support images/file `Types` of `Absolute/Relative` Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 # hexo-asset-file
+<p align="center">
+  <a href="https://npmcharts.com/compare/vue?minimal=true"><img src="https://img.shields.io/npm/dm/hexo-asset-file.svg?sanitize=true" alt="Downloads"></a>
+  <a href="https://www.npmjs.com/package/hexo-asset-file"><img src="https://img.shields.io/npm/v/hexo-asset-file.svg?sanitize=true" alt="Version"></a>
+  <a href="https://www.npmjs.com/package/hexo-asset-file"><img src="https://img.shields.io/npm/l/hexo-asset-file.svg?sanitize=true" alt="License"></a>
+</p>
+
 
 # Usege
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,131 @@
-# hexo-asset-image
-
-
-Give asset image in hexo a absolutely path automatically
+# hexo-asset-file
 
 # Usege
 
 ```shell
-npm install hexo-asset-image --save
+npm install hexo-asset-file --save
 ```
 
 # Example
 
-```shell
-MacGesture2-Publish
-├── apppicker.jpg
-├── logo.jpg
-└── rules.jpg
-MacGesture2-Publish.md
+
+
+## Config
+
+Give asset image/file in hexo a absolutely path automatically
+
+**Make sure `post_asset_folder: true` in your `_config.yml`.**
+
+```yml
+# 1. root directory:
+post_asset_folder: true
+permalink: :year/:month/:day/:title/
+url: https://tech.panqingshan.cn
+root: /
+
+# 2. child directory
+post_asset_folder: true
+permalink: :year/:month/:day/:title/
+url: https://tech.panqingshan.cn/blog
+root: /blog/
 ```
 
-Make sure `post_asset_folder: true` in your `_config.yml`.
 
-Just use `![logo](logo.jpg)` to insert `logo.jpg`.
+
+## Examples of Relative Path
+
+```shell
+source
+├── _posts
+│   ├── hello-world.md
+│   ├── MacGesture2-Publish
+│   │   ├── logo.jpg
+│   │   └── 1.pdf
+│   └── MacGesture2-Publish.md
+├── assets
+│   ├── 1.pdf
+│   └── 2.png
+├── images
+│   ├── 1.pdf
+│   └── 2.png
+├── tags
+│   └── index.md
+└── uploads
+    ├── 1.pdf
+    └── 2.png
+```
+
+Images:
+
+> Just use `Typora <img src="MacGesture2-Publish/logo.jpg" alt="logo.jpg"  />` or `![logo](MacGesture2-Publish/logo.jpg)` 
+>
+> ​	to `logo.jpg`
+>
+> ​	1:`<img src="/:year/:month/:day/:title/logo.jpg" alt="logo.jpg"  />` 或 2:`<img src="/blog/:year/:month/:day/:title/logo.jpg" alt="logo.jpg"  />`
+
+
+
+Files:
+
+> Just use `Typora <a href"MacGesture2-Publish/1.pdf">pdf</a>` or `[pdf](MacGesture2-Publish/1.pdf)` 
+>
+> ​	to `1.pdf`
+>
+> ​	1:`<a href"/:year/:month/:day/:title/1.pdf">pdf</a>` 或 2:`<a href"/blog/:year/:month/:day/:title//1.pdf">pdf</a>`
+
+
+
+## Example of Absolute Path
+
+```shell
+source
+├── _posts
+│   ├── hello-world.md
+│   ├── MacGesture2-Publish
+│   │   ├── logo.jpg
+│   │   └── MacGesture2-Publish.pdf
+│   └── MacGesture2-Publish.md
+├── assets
+│   ├── 1.pdf
+│   └── 2.png
+├── images
+│   ├── 1.pdf
+│   └── 2.png
+├── tags
+│   └── index.md
+└── uploads
+    ├── 1.pdf
+    └── 2.png
+```
+
+
+
+Images:
+
+> Just use `Typora <img src="/images/1.png" alt="logo.jpg"  />` or `![logo](/images/1.png)` 
+>
+> ​	to `/images/1.png`
+>
+> ​	1:`<img src="/images/1.png" alt="logo.jpg"  />` 或 2:`<img src="/blog/images/1.png" alt="logo.jpg"  />`
+
+
+
+Files:
+
+> Just use `Typora <a href"/uploads/1.pdf">pdf</a>` or `[pdf](/images/1.pdf)` or `[pdf](/assets/1.pdf)` or `[pdf](/uploads/1.pdf)` 
+>
+> ​	to `/images/1.png`
+>
+> ​	1:`<a href"/uploads/1.pdf">pdf</a>` 或 2:`<a href"/blog/uploads/1.pdf">pdf</a>`
+>
+> ​	1:`<a href"/images/1.pdf">pdf</a>` 或 2:`<a href"/blog/images/1.pdf">pdf</a>`
+>
+> ​	1:`<a href"/assets/1.pdf">pdf</a>` 或 2:`<a href"/blog/assets/1.pdf">pdf</a>`
 
 # History
 
+2020-12-06: support images/file `Types` of `Absolute/Relative` Path
+
 2018-04-18: support hexo-abbrlink
+
 2020-04-02: support lozad.js

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ hexo.extend.filter.register('after_post_render', function (data) {
             var src = attrSrc.replace('\\', '/');
             if (!(/http[s]*.*|\/\/.*/.test(src)
               || /^\s+\//.test(src)
-              || /^\s*\/uploads|images\//.test(src))) {
+              || /^\s*\/uploads|images|assets\//.test(src))) {
               // For "about" page, the first part of "src" can't be removed.
               // In addition, to support multi-level local directory.
               var linkArray = link.split('/').filter(function (elem) {

--- a/index.js
+++ b/index.js
@@ -10,18 +10,17 @@ hexo.extend.filter.register('after_post_render', function (data) {
   var config = hexo.config;
   if (config.post_asset_folder) {
     var link = data.permalink;
-    var beginPos = getPosition(link, '/', 3) + 1;
+    var beginPos = getPosition(link, '/', 3) ;
+    // var beginPos =
     var appendLink = '';
     // In hexo 3.1.1, the permalink of "about" page is like ".../about/index.html".
     // if not with index.html endpos = link.lastIndexOf('.') + 1 support hexo-abbrlink
+    var endPos = link.length - 1;
     if (/.*\/index\.html$/.test(link)) {
       // when permalink is end with index.html, for example 2019/02/20/xxtitle/index.html
       // image in xxtitle/ will go to xxtitle/index/
       appendLink = 'index/';
-      var endPos = link.lastIndexOf('/');
-    }
-    else {
-      var endPos = link.length - 1;
+      endPos = link.lastIndexOf('/');
     }
     link = link.substring(beginPos, endPos) + '/' + appendLink;
 
@@ -36,37 +35,71 @@ hexo.extend.filter.register('after_post_render', function (data) {
         decodeEntities: false
       });
 
-      $('img').each(function () {
-        // lazyload
-        let attrSrc = $(this).attr('src') || $(this).attr('data-src');
-        if (attrSrc) {
-          // For windows style path, we replace '\' to '/'.
-          var src = attrSrc.replace('\\', '/');
-          if (!(/http[s]*.*|\/\/.*/.test(src)
-            || /^\s+\//.test(src)
-            || /^\s*\/uploads|images\//.test(src))) {
-            // For "about" page, the first part of "src" can't be removed.
-            // In addition, to support multi-level local directory.
-            var linkArray = link.split('/').filter(function (elem) {
-              return elem != '';
-            });
-            var srcArray = src.split('/').filter(function (elem) {
-              return elem != '' && elem != '.';
-            });
-            if (srcArray.length > 1)
-              srcArray.shift();
-            src = srcArray.join('/');
-
-            if ($(this).attr('src')) {
-              $(this).attr('src', config.root + link + src);
-            } else {
-              $(this).attr('data-src', config.root + link + src);
-            }
-            console.info && console.info("update link as:-->" + config.root + link + src);
+      $('img, a').each(function () {
+        let $this = $(this);
+        let name = this.name ? this.name.toLowerCase() : "";
+        if(name === 'a' ){
+          let src = $this.attr("href");
+          // 排除不需要的
+          if(!src || /^\s+\//.test(src) || /http[s]*.*|\/\/.*|^#.*/.test(src)){
+            return ;
           }
-        } else {
-          console.info && console.info("no src attr, skipped...");
-          console.info && console.info($(this));
+          // 简单处理assets/images/uploads开头的: /assets
+          if (/^\/(assets|images|uploads)\/.*/.test(src)){
+            let newSrc = config.root.replace(/\/+$/, "") + src;
+            $this.attr('href', newSrc);
+            console.info && console.info("update global assets as:-->" + newSrc);
+            return ;
+          }
+          // 切割匹配
+          var linkArray = link.split('/').filter(el => el != '');
+          var srcArray = src.split('/').filter(el => el != '' && el != '.');
+          // asset名称可以对上
+          if(!linkArray.length || !srcArray.length || linkArray[linkArray.length - 1] !== srcArray[0]){
+            return ;
+          }
+          // post_name/a.pdf -> a.pdf
+          if (srcArray.length > 1)
+            srcArray.shift();
+          src = srcArray.join('/');
+
+          if ($this.attr('href')) {
+            $this.attr('href', link + src);
+          }
+          console.info && console.info("update href as:-->" + link + src);
+          // content
+        }else if(name === 'img'){
+           // lazyload
+          let attrSrc = $this.attr('src') || $this.attr('data-src');
+          if (attrSrc) {
+            // For windows style path, we replace '\' to '/'.
+            var src = attrSrc.replace('\\', '/');
+            if (!(/http[s]*.*|\/\/.*/.test(src)
+              || /^\s+\//.test(src)
+              || /^\s*\/uploads|images\//.test(src))) {
+              // For "about" page, the first part of "src" can't be removed.
+              // In addition, to support multi-level local directory.
+              var linkArray = link.split('/').filter(function (elem) {
+                return elem != '';
+              });
+              var srcArray = src.split('/').filter(function (elem) {
+                return elem != '' && elem != '.';
+              });
+              if (srcArray.length > 1)
+                srcArray.shift();
+              src = srcArray.join('/');
+
+              if ($this.attr('src')) {
+                $this.attr('src', link + src);
+              } else {
+                $this.attr('data-src', link + src);
+              }
+              console.info && console.info("update link as:-->" + link + src);
+            }
+          } else {
+            console.info && console.info("no src attr, skipped...");
+            console.info && console.info($this);
+          }
         }
       });
       data[key] = $.html();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-asset-file",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Give asset image or file in hexo a absolutely or relavtive path automatically | 自动处理图片或附件",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-asset-file",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Give asset image or file in hexo a absolutely or relavtive path automatically | 自动处理图片或附件",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "hexo-asset-image",
-  "version": "0.0.5",
-  "description": "Give asset image in hexo a absolutely path automatically",
+  "name": "hexo-asset-file",
+  "version": "1.0.1",
+  "description": "Give asset image or file in hexo a absolutely or relavtive path automatically | 自动处理图片或附件",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -10,12 +10,21 @@
     "hexo",
     "iamge",
     "asset",
-    "path"
+    "path",
+    "file",
+    "hexo 附件",
+    "hexo 图片",
+    "hexo 文件"
   ],
-  "author": "xcodebuild",
+  "author": "qingshan-dev",
   "license": "MIT",
   "dependencies": {
     "cheerio": "^0.19.0",
     "entities": "^1.1.2"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/qingshan-dev/hexo-asset-image.git"
+  },
+  "homepage": "https://github.com/qingshan-dev/hexo-asset-image#hexo-asset-file"
 }


### PR DESCRIPTION
2020-12-06: support images/files Types of Absolute/Relative Path
2020-12-07:
支持图片或附件的相对和绝对路径
支持根目录(tech.example.com)或子目录(tech.example.com/blog)部署
更新多的请看https://github.com/qingshan-dev/hexo-asset-image#readme
